### PR TITLE
Fix 1.19.3

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   "depends": {
     "fabricloader": ">=0.14.9",
     "fabric-api": "*",
-    "minecraft": "1.19.2",
+    "minecraft": "~1.19.2",
     "java": ">=17"
   },
   "suggests": {


### PR DESCRIPTION
Fix 1.19.3 by making the compatible version(s) declared in `fabric.mod.json` less strict.